### PR TITLE
[SCR-85] Added Trusted Publisher Configuration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,8 @@
 name: Publish Package
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+      types: [published]
 
 permissions:
   id-token: write  # Required for OIDC
@@ -13,11 +12,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: 14.x
           registry-url: 'https://registry.npmjs.org'
 
       # Ensure npm 11.5.1 or later is installed
@@ -25,5 +24,4 @@ jobs:
         run: npm install -g npm@latest
       - run: npm ci
       - run: npm run build --if-present
-      - run: npm test
       - run: npm publish


### PR DESCRIPTION
# Problem
Security Update: npm classic token creation is now disabled. Existing classic tokens will be revoked on December 9, 2025. Migrate to trusted publishing or granular access tokens to avoid disruption. [Learn more](https://gh.io/npm-token-changes).

# Solution
We have deleted all of the existing Publish and Automation tokens from npm. Publish tokens are safe to delete. Since, our automation token was tied to the github action of this repository, we needed to re-implement this either by using a rotating token strategy or by using a Trusted Publisher. Because Trusted Publisher was the recommended and easiest approach, we have enabled Trusted Publisher from our [npm package settings](https://www.npmjs.com/package/scrapingbee/access) and changed the `publish.yml` file to use the Trusted Publisher configuration.